### PR TITLE
指定したクエリを日時実行させる内容へ変更

### DIFF
--- a/aws/buildspec.yml
+++ b/aws/buildspec.yml
@@ -12,6 +12,8 @@ phases:
     commands:
       - echo AWS resource copy to S3
       - aws s3 sync --exact-timestamps --delete aws/stepfunctions/ s3://quark-cicd-test/stepfunctions/
+      - aws s3 sync --exact-timestamps --delete aws/s3/create_table_query/ s3://quark-cicd-test/s3/create_table_query/
+      - aws s3 sync --exact-timestamps --delete aws/lambda/src/ s3://quark-cicd-test/lambda/src/
 
       - echo datamart build for cloudformation
       - aws cloudformation package --template-file aws/cloudformation/datamart-cicd.yml --s3-bucket quark-cicd-test --s3-prefix cloudformation/package --output-template-file /tmp/cloudformation-datamart-cicd.yml

--- a/aws/cloudformation/datamart-cicd.yml
+++ b/aws/cloudformation/datamart-cicd.yml
@@ -1,10 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: An example template for a Step Functions state machine.
 Resources:
+    # IAM Role
     StepFunctionServiceRole:
         Type: "AWS::IAM::Role"
         Properties:
-            RoleName: HelloWorldEasy
+            RoleName: DatamartUpdateRole
             AssumeRolePolicyDocument:
                 Version: "2012-10-17"
                 Statement:
@@ -13,29 +14,44 @@ Resources:
                           Service:
                               - states.amazonaws.com
                               - scheduler.amazonaws.com
+                              - lambda.amazonaws.com
                       Action: sts:AssumeRole
             ManagedPolicyArns: [arn:aws:iam::aws:policy/AdministratorAccess]
+    # Lambda
+    AthenaQueryExecution:
+        Type: "AWS::Lambda::Function"
+        Properties:
+            Code:
+                S3Bucket: quark-cicd-test
+                S3Key: lambda/src/athena-query-execution/lambda_function.py
+            FunctionName: athena-query-execution
+            Handler: lambda_function.lambda_handler
+            Role: !GetAtt StepFunctionServiceRole.Arn
+            Runtime: python3.9
+            Timeout: 60
+    # StepFunctions
     StepFunctionStateMachine:
         Type: "AWS::StepFunctions::StateMachine"
         Properties:
-            StateMachineName: HelloWorldEasy
+            StateMachineName: AthenaQueryExecute
             StateMachineType: STANDARD
             DefinitionS3Location:
                 Bucket: quark-cicd-test
-                Key: stepfunctions/HelloWorld-easy.yml
+                Key: stepfunctions/daily_update_datamart.json
             RoleArn: !GetAtt StepFunctionServiceRole.Arn
         Metadata:
             "AWS::CloudFormation::Designer":
                 id: 03217ee1-4cfd-4fee-804c-7a35f8901f6c
+    # EventBridge Scheduler
     StepFunctionExecutionSchedule:
         Type: "AWS::Scheduler::Schedule"
         Properties:
-            Description: HelloWorldEasy StepFunction Excecution Schedule
+            Description: AthenaQueryExecute StepFunction Daily Excecution
             ScheduleExpression: "cron(0 1 * * ? *)"
             FlexibleTimeWindow:
                 Mode: FLEXIBLE
-                MaximumWindowInMinutes: 60
-            Name: HelloWorldEasyEverydayExecution-for-CloudFormation
+                MaximumWindowInMinutes: 15
+            Name: AthenaQueryDailyExecution
             Target:
                 Arn: !Ref StepFunctionStateMachine
                 RoleArn: !GetAtt StepFunctionServiceRole.Arn

--- a/aws/lambda/src/athena-query-execution/lambda_function.py
+++ b/aws/lambda/src/athena-query-execution/lambda_function.py
@@ -1,0 +1,23 @@
+import boto3
+
+
+def lambda_handler(event, context):
+    query = ''
+    
+    if 'query' in event:
+        query = event['query']
+    else:
+        s3_bucket = event['bucket']
+        object_key = event['file_key']
+        
+        s3 = boto3.client('s3')
+        response_s3 = s3.get_object(Bucket = s3_bucket, Key = object_key)
+        query = response_s3['Body'].read().decode('utf-8')
+    
+    # queryの中身が''の場合エラーをスロー
+    if not query:
+        raise Exception('クエリ文字列が正しく設定されませんでした')
+    
+    return {
+        'query' : query
+    }

--- a/aws/s3/create_table_query/riiid_aggregate.sql
+++ b/aws/s3/create_table_query/riiid_aggregate.sql
@@ -1,0 +1,9 @@
+CREATE TABLE datamart.riiid_aggregate WITH (
+    format = 'PARQUET',
+    external_location = 's3://quark-datamart/riiid_aggregate/'
+) AS
+SELECT user_id,
+    COUNT(answered_correctly) as answer_number,
+    AVG(answered_correctly) as correct_answer_rate
+FROM main_data.riiid_train_data
+GROUP BY user_id

--- a/aws/stepfunctions/daily_update_datamart.json
+++ b/aws/stepfunctions/daily_update_datamart.json
@@ -1,0 +1,27 @@
+{
+  "StartAt": "CallLambda",
+  "States": {
+    "CallLambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "FunctionName": "athena-query-execute",
+        "Payload": {
+          "bucket": "quark-cicd-test",
+          "file_key": "s3/create_table_query/riiid_aggregate.sql"
+        }
+      },
+      "Next": "QueryExecute"
+    },
+    "QueryExecute": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
+      "Parameters": {
+        "QueryString.$": "$.query",
+        "WorkGroup": "primary"
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
# 詳細
以前は[HelloWorld-easy.yml](https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/blob/master/aws/stepfunctions/HelloWorld-easy.yml)をEventBridgeで定期実行できるような環境だったが、[riiid_aggregate.sql](https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/blob/cd5136d0f8af378555875933e2f58c4a4ef62f63/aws/s3/create_table_query/riiid_aggregate.sql)をEventBridgeで定期実行できるような環境に変更した

