### PR TITLE
zipファイル作成先ディレクトリを作成

### DIFF
--- a/aws/script/create_zip_files.sh
+++ b/aws/script/create_zip_files.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 WORKDIR='/tmp/lambda/zip/'
+mkdir -p ${WORKDIR}
 
 cd aws/lambda/src
 for dir in `ls -d */`


### PR DESCRIPTION
# 対応内容
- 事前にWORKDIRのディレクトリを作成しておらずCodeBuildでコケたので修正 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/9474a36673c83dc29741334cbce1ea63ca0e79d3