### PR TITLE
s3 syncコマンドを一部削除

### DIFF
--- a/aws/buildspec.yml
+++ b/aws/buildspec.yml
@@ -14,7 +14,6 @@ phases:
       - echo AWS resource copy to S3
       - aws s3 sync --exact-timestamps --delete aws/stepfunctions/ s3://quark-cicd-test/stepfunctions/
       - aws s3 sync --exact-timestamps --delete aws/s3/create_table_query/ s3://quark-cicd-test/s3/create_table_query/
-      - aws s3 sync --exact-timestamps --delete aws/lambda/src/ s3://quark-cicd-test/lambda/src/
 
       - echo datamart build for cloudformation
       - aws cloudformation package --template-file aws/cloudformation/datamart-cicd.yml --s3-bucket quark-cicd-test --s3-prefix cloudformation/package --output-template-file /tmp/cloudformation-datamart-cicd.yml


### PR DESCRIPTION
# 対応内容
- s3 syncを同じS3 URIに対して2度行っていたので2回目を削除 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/585de32b7e0b2f95cd9aa4946a51086f50029e9d
  - 1回目は[bashファイルの中で実行](https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/blob/master/aws/script/create_zip_files.sh#L12)