### PR TITLE
複数テーブルの更新に対応&Lambda関数zipファイル作成時の多重フォルダ構造を修正

### DIFF
--- a/aws/buildspec.yml
+++ b/aws/buildspec.yml
@@ -9,6 +9,7 @@ phases:
     commands:
       - echo Create Lambda Function zip
       - bash aws/script/create_zip_files.sh
+      - bash aws/script/create_map_inputs.sh
   post_build:
     commands:
       - echo AWS resource copy to S3

--- a/aws/buildspec.yml
+++ b/aws/buildspec.yml
@@ -9,6 +9,7 @@ phases:
     commands:
       - echo Create Lambda Function zip
       - bash aws/script/create_zip_files.sh
+      - echo Create Step Functions Distributed Map Input Parameter
       - bash aws/script/create_map_inputs.sh
   post_build:
     commands:

--- a/aws/cloudformation/datamart-cicd.yml
+++ b/aws/cloudformation/datamart-cicd.yml
@@ -66,7 +66,6 @@ Resources:
             Target:
                 Arn: !Ref StepFunctionStateMachine
                 RoleArn: !GetAtt StepFunctionServiceRole.Arn
-                Input: '{"bucket": "quark-cicd-test", "file_key": "s3/create_table_query/riiid_aggregate.sql"}'
 Metadata:
     "AWS::CloudFormation::Designer":
         03217ee1-4cfd-4fee-804c-7a35f8901f6c:

--- a/aws/s3/create_table_query/hnm_aggregate.sql
+++ b/aws/s3/create_table_query/hnm_aggregate.sql
@@ -1,0 +1,9 @@
+CREATE TABLE datamart.hnm_aggregate WITH (
+    format = 'PARQUET',
+    external_location = 's3://quark-datamart/hnm_aggregate/'
+) AS
+SELECT club_member_status,
+    AVG(try_cast(recency as double)) as avg_recency,
+    AVG(try_cast(total_purchase as double)) as avg_total_purchase
+FROM h_and_m.customers
+GROUP BY club_member_status

--- a/aws/s3/create_table_query/practice_sales.sql
+++ b/aws/s3/create_table_query/practice_sales.sql
@@ -1,0 +1,6 @@
+CREATE TABLE datamart.practice_sales WITH (
+    format = 'PARQUET',
+    external_location = 's3://quark-datamart/practice_sales/'
+) AS
+SELECT *
+FROM main_data.practice_sales

--- a/aws/s3/create_table_query/test.sql
+++ b/aws/s3/create_table_query/test.sql
@@ -1,3 +1,0 @@
-SELECT *
-FROM main_data.practice_user
-LIMIT 10

--- a/aws/script/create_map_inputs.sh
+++ b/aws/script/create_map_inputs.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+TARGET_FILE='aws/stepfunctions/distributed-map-source.csv'
+echo "bucket,file_key" >> ${TARGET_FILE}
+for f in `ls aws/s3/create_table_query | grep .sql`
+do
+    echo "quark-cicd-test,s3/create_table_query/${f}" >> ${TARGET_FILE}
+done
+
+aws s3 cp ${TARGET_FILE} s3://quark-cicd-test/stepfunctions/distributed-map-source.csv

--- a/aws/script/create_zip_files.sh
+++ b/aws/script/create_zip_files.sh
@@ -6,7 +6,7 @@ mkdir -p ${WORKDIR}
 cd aws/lambda/src
 for dir in `ls -d */`
 do
-    zip -r ${WORKDIR}`basename ${dir}`.zip `basename ${dir}`
+    zip -r -j ${WORKDIR}`basename ${dir}`.zip `ls ${dir}/* | grep lambda_function.py`
 done
 
 aws s3 sync --exact-timestamps --delete ${WORKDIR} s3://quark-cicd-test/lambda/src/

--- a/aws/stepfunctions/create_datamart.json
+++ b/aws/stepfunctions/create_datamart.json
@@ -6,7 +6,7 @@
       "Resource": "arn:aws:states:::lambda:invoke",
       "OutputPath": "$.Payload",
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:athena-query-scanning:$LATEST",
+              "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:athena-query-scan:$LATEST",
         "Payload.$": "$"
       },
       "Next": "Choice"

--- a/aws/stepfunctions/create_datamart.json
+++ b/aws/stepfunctions/create_datamart.json
@@ -1,85 +1,118 @@
 {
-  "StartAt": "CallLambda",
+  "StartAt": "Map",
   "States": {
-    "CallLambda": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "OutputPath": "$.Payload",
-      "Parameters": {
-              "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:athena-query-scan:$LATEST",
-        "Payload.$": "$"
-      },
-      "Next": "Choice"
-    },
-    "Choice": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.table",
-          "StringEquals": "",
-          "Next": "QueryExecute"
-        }
-      ],
-      "Default": "Parallel"
-    },
-    "Parallel": {
-      "Type": "Parallel",
-      "Next": "QueryExecute",
-      "Branches": [
-        {
-          "StartAt": "Athena StartQueryExecution",
-          "States": {
-            "Athena StartQueryExecution": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
-              "Parameters": {
-                "QueryString.$": "$.table",
-                "WorkGroup": "primary"
-              },
-              "End": true
-            }
-          }
+    "Map": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD"
         },
-        {
-          "StartAt": "Lambda Invoke (1)",
-          "States": {
-            "Lambda Invoke (1)": {
-              "Type": "Task",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "OutputPath": "$.Payload",
-              "Parameters": {
-                "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:delete-s3-objects:$LATEST",
-                "Payload": {
-                  "bucket.$": "$.s3_bucket",
-                  "file_key.$": "$.s3_key"
+        "StartAt": "CallLambda",
+        "States": {
+          "CallLambda": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "OutputPath": "$.Payload",
+            "Parameters": {
+              "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:athena-query-scan:$LATEST",
+              "Payload.$": "$"
+            },
+            "Next": "Choice"
+          },
+          "Choice": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "Variable": "$.table",
+                "StringEquals": "",
+                "Next": "QueryExecute"
+              }
+            ],
+            "Default": "Parallel"
+          },
+          "Parallel": {
+            "Type": "Parallel",
+            "Branches": [
+              {
+                "StartAt": "Athena StartQueryExecution",
+                "States": {
+                  "Athena StartQueryExecution": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
+                    "Parameters": {
+                      "QueryString.$": "$.table",
+                      "WorkGroup": "primary"
+                    },
+                    "End": true
+                  }
                 }
               },
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.AWSLambdaException",
-                    "Lambda.SdkClientException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "IntervalSeconds": 2,
-                  "MaxAttempts": 6,
-                  "BackoffRate": 2
+              {
+                "StartAt": "Lambda Invoke",
+                "States": {
+                  "Lambda Invoke": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::lambda:invoke",
+                    "OutputPath": "$.Payload",
+                    "Parameters": {
+                      "FunctionName": "arn:aws:lambda:ap-northeast-1:875141268485:function:delete-s3-objects:$LATEST",
+                      "Payload": {
+                        "bucket.$": "$.s3_bucket",
+                        "file_key.$": "$.s3_key"
+                      }
+                    },
+                    "Retry": [
+                      {
+                        "ErrorEquals": [
+                          "Lambda.ServiceException",
+                          "Lambda.AWSLambdaException",
+                          "Lambda.SdkClientException",
+                          "Lambda.TooManyRequestsException"
+                        ],
+                        "IntervalSeconds": 2,
+                        "MaxAttempts": 6,
+                        "BackoffRate": 2
+                      }
+                    ],
+                    "End": true
+                  }
                 }
-              ],
-              "End": true
-            }
+              }
+            ],
+            "ResultPath": null,
+            "Next": "QueryExecute"
+          },
+          "QueryExecute": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
+            "Parameters": {
+              "QueryString.$": "$.query",
+              "WorkGroup": "primary"
+            },
+            "End": true
           }
         }
-      ],
-      "ResultPath": null
-    },
-    "QueryExecute": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
-      "Parameters": {
-        "QueryString.$": "$.query",
-        "WorkGroup": "primary"
+      },
+      "Label": "Map",
+      "MaxConcurrency": 1000,
+      "ItemReader": {
+        "Resource": "arn:aws:states:::s3:getObject",
+        "ReaderConfig": {
+          "InputType": "CSV",
+          "CSVHeaderLocation": "FIRST_ROW"
+        },
+        "Parameters": {
+          "Bucket": "quark-cicd-test",
+          "Key": "stepfunctions/distributed-map-source.csv"
+        }
+      },
+      "ResultWriter": {
+        "Resource": "arn:aws:states:::s3:putObject",
+        "Parameters": {
+          "Bucket": "step-functions-map-results-875141268485-ap-northeast-1",
+          "Prefix": "/"
+        }
       },
       "End": true
     }


### PR DESCRIPTION
close #26 
close #20 

# 対応内容
- StepFunctionsにて指定するLambdaを間違えていたので修正 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/a5bbe76864bf3d566042720affbeaab59dbb4b10
  - あとで直接記入ではない形で実装する
- Step FunctionsにDistributed Map機能を追加 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/7591ff613a628c476686bd0521dbb057b1363a95
  - Distributed Mapで並列に実行するそれぞれに対して入力を与えるファイルを追加 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/663435f1f322d8a853041d3db47b0bff609ca8f7
  - CodeBuildでDistributed Map入力用 csvファイルを配置するよう変更 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/8ee07178a08ac2e6aed5cd548bef6455e8322904
    - それに伴いCloudFormation側の入力用の値を削除
- Lambdaの関数作成用zipファイルのディレクトリ構造が多重になっているのを解消 https://github.com/nijigen-plot/AWS-datamart-cicd-sourcecode/commit/7a50d6a915d920c66d8eae837c62e57051ea12f6